### PR TITLE
Fix is_merged dimension

### DIFF
--- a/views/pull_request.view.lkml
+++ b/views/pull_request.view.lkml
@@ -91,7 +91,7 @@ view: pull_request {
 
   dimension: is_merged {
     type: yesno
-    sql: ${merge_commit_sha} IS NULL ;;
+    sql: ${merge_commit_sha} IS NOT NULL ;;
   }
 
   measure: count {


### PR DESCRIPTION
The value must be reversed - current condition incorrectly represents a PR without a merge commit as merged.