### PR TITLE
Added merge_commit to explore

### DIFF
--- a/explores/pull_request.explore.lkml
+++ b/explores/pull_request.explore.lkml
@@ -5,6 +5,7 @@ include: "/views/requested_reviewer_history.view"
 include: "/views/pull_request_review.view"
 include: "/views/pull_request_review_dismissed.view"
 include: "/views/user.view"
+include: "/views/commit.view.lkml"
 
 explore: pull_request {
   join: issue {
@@ -54,6 +55,13 @@ explore: pull_request {
     from: repository
     type: left_outer
     sql_on: ${repository_head.id} = ${pull_request.head_repo_id} ;;
+    relationship: many_to_one
+  }
+  join: merge_commit {
+    view_label: "Merge commit"
+    from: commit
+    type: left_outer
+    sql_on ${pull_request.merge_commit_sha} = ${commit.sha} ;;
     relationship: many_to_one
   }
 


### PR DESCRIPTION
Hello, everyone! 

Sometimes it's very important to know what kind of commit closed the bullet-request (who did it, date, and other stuff).

That's why I added this information to the open-source model.